### PR TITLE
Issue 27 build admin lock account flow in demo app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,6 @@ dependencies {
     // OpenAPI (Swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
-    // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:3.1.1'
-
     // Runtime dependencies
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.5.2'
@@ -69,7 +66,6 @@ dependencies {
     implementation 'com.google.guava:guava:33.4.5-jre'
     implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.2.Final'
-
 
     // Compile-only dependencies
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/static/js/admin/admin-action.js
+++ b/src/main/resources/static/js/admin/admin-action.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('adminActionForm');
+    const usernameInput = document.getElementById('username');
+    const actionSelect = document.getElementById('actionType');
+    const globalMessage = document.getElementById('globalMessage');
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const email = usernameInput.value.trim();
+        const action = actionSelect.value;
+
+        if (!email || !action) {
+            showMessage('Please fill all fields', 'danger');
+            return;
+        }
+
+        const endpoint = action === 'LOCK' ? '/admin/lockAccount' : '/admin/unlockAccount';
+
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    "Content-Type": "application/json",
+                    [document.querySelector("meta[name='_csrf_header']").content]:
+                    document.querySelector("meta[name='_csrf']").content,
+                },
+                body: JSON.stringify({ email }),
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                showMessage(result.messages[0] || 'Action successful!', 'success');
+            } else {
+                showMessage(result.messages[0] || 'Something went wrong.', 'danger');
+            }
+        } catch (error) {
+            console.error(error);
+            showMessage('Error occurred while performing action', 'danger');
+        }
+    });
+
+    function showMessage(message, type) {
+        globalMessage.className = `alert alert-${type} text-center`;
+        globalMessage.textContent = message;
+        globalMessage.classList.remove('d-none');
+    }
+});

--- a/src/main/resources/templates/admin/actions.html
+++ b/src/main/resources/templates/admin/actions.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" layout:decorate="~{layout}">
+
+<head>
+    <title>Admin Actions</title>
+</head>
+
+<body>
+<div layout:fragment="content">
+    <section id="main_content" class="my-5">
+        <div class="container">
+            <div class="text-center mb-4">
+                <h1>Admin Actions</h1>
+            </div>
+
+            <div id="globalMessage" class="alert alert-info text-center d-none"></div>
+
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <form id="adminActionForm">
+                        <div class="row mb-3 align-items-center">
+                            <label for="username" class="col-sm-3 col-form-label">Username / Email</label>
+                            <div class="col-sm-7">
+                                <input type="text" id="username" name="username" class="form-control" required>
+                                <div id="usernameError" class="form-text text-danger d-none"></div>
+                            </div>
+                        </div>
+
+                        <!-- Action Type -->
+                        <div class="row mb-4 align-items-center">
+                            <label for="actionType" class="col-sm-3 col-form-label">Action</label>
+                            <div class="col-sm-7">
+                                <select id="actionType" name="actionType" class="form-select" required>
+                                    <option value="">Select Action</option>
+                                    <option value="LOCK">Lock Account</option>
+                                    <option value="UNLOCK">Unlock Account</option>
+                                </select>
+                                <div id="actionTypeError" class="form-text text-danger d-none"></div>
+                            </div>
+                        </div>
+
+                        <!-- Submit Button -->
+                        <div class="text-center">
+                            <button type="submit" class="btn btn-danger">Submit</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <script type="module" th:src="@{/js/admin/admin-action.js}"></script>
+</div>
+</body>
+
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -45,6 +45,9 @@
 						<ul class="dropdown-menu dropdown-menu-end" aria-labelledby="accountDropdown">
 							<li><a class="dropdown-item" th:href="${@environment.getProperty('user.security.updateUserURI')}">Update Account</a></li>
 							<li><a class="dropdown-item" th:href="@{/user/update-password.html}">Change Password</a></li>
+							<li sec:authorize="hasAuthority('ADMIN_PRIVILEGE')">
+								<a class="dropdown-item" th:href="@{/admin/actions.html}">Admin Actions</a>
+							</li>
 							<li>
 								<form th:action="@{/user/logout}" method="POST" class="d-inline">
 									<button class="dropdown-item" type="submit">Logout</button>


### PR DESCRIPTION
This pull request introduces a new feature for admin actions, allowing administrators to lock and unlock user accounts through a web interface. The changes include the addition of a new HTML template for the admin actions page, a JavaScript file to handle form submissions, and an update to the header to include a link to the new admin actions page.

New feature for admin actions:

* [`src/main/resources/templates/admin/actions.html`](diffhunk://#diff-47f3f180f033d0f2823748493f26fda2df9eb9d36d219b8fb03f5d3178c8b4e2R1-R56): Added a new HTML template for the admin actions page, which includes a form for locking and unlocking user accounts.
* [`src/main/resources/static/js/admin/admin-action.js`](diffhunk://#diff-9f287b4bdaafe08c3914bb4bd773c79769f048f8e9732bff275a9252aa2b0e48R1-R49): Added a new JavaScript file to handle form submissions, including validation and asynchronous requests to the server.

Header update:

* [`src/main/resources/templates/fragments/header.html`](diffhunk://#diff-0d7892b0f2971801bf76afc5430089770b08f7a574b7045294f37707faf6cfa6R48-R50): Updated the header to include a link to the new admin actions page, visible only to users with the `ADMIN_PRIVILEGE` authority.