### PR TITLE
Issue 31 delete account not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:3.2.0'
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:3.2.1'
 
     // Spring Boot starters
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/com/digitalsanctuary/spring/demo/user/profile/EventRegistration.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/user/profile/EventRegistration.java
@@ -1,6 +1,7 @@
 package com.digitalsanctuary.spring.demo.user.profile;
 
 import com.digitalsanctuary.spring.demo.event.Event;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -19,9 +20,9 @@ public class EventRegistration {
     private Long id;
 
     @ToString.Exclude
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE)
     private DemoUserProfile userProfile;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.REMOVE)
     private Event event;
 }

--- a/src/main/java/com/digitalsanctuary/spring/demo/user/profile/UserProfileDeletionListener.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/user/profile/UserProfileDeletionListener.java
@@ -1,0 +1,45 @@
+package com.digitalsanctuary.spring.demo.user.profile;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.digitalsanctuary.spring.user.event.UserPreDeleteEvent;
+
+/**
+ * Listener for user profile deletion events. This class listens for UserPreDeleteEvent and deletes the associated DemoUserProfile. It is assumed that
+ * the DemoUserProfile is mapped to the User entity with a one-to-one relationship.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserProfileDeletionListener {
+    private final DemoUserProfileRepository demoUserProfileRepository;
+    // Inject other repositories if needed (e.g., EventRegistrationRepository)
+
+    @EventListener
+    @Transactional // Joins the transaction started by UserService.deleteUserAccount
+    public void handleUserPreDelete(UserPreDeleteEvent event) {
+        Long userId = event.getUser().getId();
+        log.info("Received UserPreDeleteEvent for userId: {}. Deleting associated DemoUserProfile...", userId);
+
+        // Option 1: Delete profile directly (if no further cascades needed from profile)
+        // Since DemoUserProfile uses @MapsId, its ID is the same as the User's ID
+        demoUserProfileRepository.findById(userId).ifPresent(profile -> {
+            log.debug("Found DemoUserProfile for userId: {}. Deleting...", userId);
+            // If DemoUserProfile itself has relationships needing cleanup (like EventRegistrations)
+            // that aren't handled by CascadeType.REMOVE or orphanRemoval=true,
+            // handle them here *before* deleting the profile.
+            // Example: eventRegistrationRepository.deleteByUserProfile(profile);
+            demoUserProfileRepository.delete(profile);
+            log.debug("DemoUserProfile deleted for userId: {}", userId);
+        });
+
+        // Option 2: If DemoUserProfile has CascadeType.REMOVE/orphanRemoval=true
+        // on its collections (like eventRegistrations), deleting the profile might be enough.
+        // demoUserProfileRepository.deleteById(userId);
+
+        log.info("Finished processing UserPreDeleteEvent for userId: {}", userId);
+    }
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/service/UserServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/service/UserServiceTest.java
@@ -1,5 +1,17 @@
 package com.digitalsanctuary.spring.user.service;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import com.digitalsanctuary.spring.user.dto.UserDto;
 import com.digitalsanctuary.spring.user.exceptions.UserAlreadyExistException;
 import com.digitalsanctuary.spring.user.persistence.model.Role;
@@ -8,19 +20,6 @@ import com.digitalsanctuary.spring.user.persistence.repository.PasswordResetToke
 import com.digitalsanctuary.spring.user.persistence.repository.RoleRepository;
 import com.digitalsanctuary.spring.user.persistence.repository.UserRepository;
 import com.digitalsanctuary.spring.user.persistence.repository.VerificationTokenRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.session.SessionRegistry;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -42,6 +41,9 @@ public class UserServiceTest {
     public UserEmailService userEmailService;
     @Mock
     public UserVerificationService userVerificationService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Mock
     public AuthorityService authorityService;
@@ -72,7 +74,7 @@ public class UserServiceTest {
         testUserDto.setRole(1);
 
         userService = new UserService(userRepository, tokenRepository, passwordTokenRepository, passwordEncoder, roleRepository, sessionRegistry,
-                userEmailService, userVerificationService, authorityService, dsUserDetailsService);
+                userEmailService, userVerificationService, authorityService, dsUserDetailsService, eventPublisher);
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces several changes to the `EventRegistration`, `UserProfileDeletionListener`, and `UserServiceTest` classes to enhance functionality and improve test coverage.

Enhancements to event handling and user profile management:

* [`src/main/java/com/digitalsanctuary/spring/demo/user/profile/EventRegistration.java`](diffhunk://#diff-2cae06fe2bb10d5459f3a4b637e47e517ddd9d05efa955637b7500ec373ebb60L22-R26): Added `CascadeType.REMOVE` to `@ManyToOne` annotations for `userProfile` and `event` to ensure related entities are removed when an `EventRegistration` is deleted.
* [`src/main/java/com/digitalsanctuary/spring/demo/user/profile/UserProfileDeletionListener.java`](diffhunk://#diff-4c9b0085f01ba2084eb033ff66d047cc1f04ddd22eb2bd1784ed4edc1aa645c7R1-R45): Introduced a new listener class to handle `UserPreDeleteEvent` and delete associated `DemoUserProfile` entities.

Improvements to test coverage:

* [`src/test/java/com/digitalsanctuary/spring/user/service/UserServiceTest.java`](diffhunk://#diff-3f270fc4837d9b033ce8828c5509e19ce70f0192d660a068421230bf1b4215b8L3-R22): Refactored imports for clarity and added a mock for `ApplicationEventPublisher` to enhance the testing of user service functionality. [[1]](diffhunk://#diff-3f270fc4837d9b033ce8828c5509e19ce70f0192d660a068421230bf1b4215b8L3-R22) [[2]](diffhunk://#diff-3f270fc4837d9b033ce8828c5509e19ce70f0192d660a068421230bf1b4215b8R45-R47) [[3]](diffhunk://#diff-3f270fc4837d9b033ce8828c5509e19ce70f0192d660a068421230bf1b4215b8L75-R77)