### PR TITLE
feat: Add sample RegistrationGuard for domain-restricted registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:4.2.3-SNAPSHOT'
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:4.3.0'
 
     // WebAuthn support (Passkey authentication)
     implementation 'org.springframework.security:spring-security-webauthn'

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:4.2.1'
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:4.2.3-SNAPSHOT'
 
     // WebAuthn support (Passkey authentication)
     implementation 'org.springframework.security:spring-security-webauthn'

--- a/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
@@ -2,6 +2,7 @@ package com.digitalsanctuary.spring.demo.registration;
 
 import java.util.Locale;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +14,8 @@ import com.digitalsanctuary.spring.user.registration.RegistrationSource;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Sample {@link RegistrationGuard} that restricts form and passwordless registration to
- * {@code @example.com} email addresses while allowing all OAuth2/OIDC registrations.
+ * Sample {@link RegistrationGuard} that restricts form and passwordless registration to a
+ * configurable email domain while allowing all OAuth2/OIDC registrations.
  *
  * <p>This guard is only active when the {@code registration-guard} Spring profile is enabled.
  * To try it out, add {@code registration-guard} to your active profiles:</p>
@@ -22,6 +23,9 @@ import lombok.extern.slf4j.Slf4j;
  * <pre>
  * ./gradlew bootRun --args='--spring.profiles.active=local,registration-guard'
  * </pre>
+ *
+ * <p>The allowed domain can be configured via the {@code registration.guard.allowed-domain}
+ * property (defaults to {@code @example.com}).</p>
  *
  * <p>See the
  * <a href="https://github.com/devondragon/SpringUserFramework/blob/main/REGISTRATION-GUARD.md">
@@ -36,7 +40,12 @@ import lombok.extern.slf4j.Slf4j;
 @Profile("registration-guard")
 public class DomainRegistrationGuard implements RegistrationGuard {
 
-    private static final String ALLOWED_DOMAIN = "@example.com";
+    private final String allowedDomain;
+
+    public DomainRegistrationGuard(
+            @Value("${registration.guard.allowed-domain:@example.com}") String allowedDomain) {
+        this.allowedDomain = allowedDomain.toLowerCase(Locale.ROOT);
+    }
 
     @Override
     public RegistrationDecision evaluate(RegistrationContext context) {
@@ -51,13 +60,13 @@ public class DomainRegistrationGuard implements RegistrationGuard {
         }
 
         // For form/passwordless, restrict to the allowed domain
-        if (context.email() != null && context.email().toLowerCase(Locale.ROOT).endsWith(ALLOWED_DOMAIN)) {
+        if (context.email() != null && context.email().toLowerCase(Locale.ROOT).endsWith(allowedDomain)) {
             log.debug("Allowing registration for approved domain: {}", context.email());
             return RegistrationDecision.allow();
         }
 
         log.info("Denied registration for: {} (domain not allowed)", context.email());
         return RegistrationDecision.deny(
-                "Registration is restricted to " + ALLOWED_DOMAIN + " email addresses.");
+                "Registration is restricted to " + allowedDomain + " email addresses.");
     }
 }

--- a/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
@@ -1,0 +1,61 @@
+package com.digitalsanctuary.spring.demo.registration;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.digitalsanctuary.spring.user.registration.RegistrationContext;
+import com.digitalsanctuary.spring.user.registration.RegistrationDecision;
+import com.digitalsanctuary.spring.user.registration.RegistrationGuard;
+import com.digitalsanctuary.spring.user.registration.RegistrationSource;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Sample {@link RegistrationGuard} that restricts form and passwordless registration to
+ * {@code @example.com} email addresses while allowing all OAuth2/OIDC registrations.
+ *
+ * <p>This guard is only active when the {@code registration-guard} Spring profile is enabled.
+ * To try it out, add {@code registration-guard} to your active profiles:</p>
+ *
+ * <pre>
+ * ./gradlew bootRun --args='--spring.profiles.active=local,registration-guard'
+ * </pre>
+ *
+ * <p>See the
+ * <a href="https://github.com/devondragon/SpringUserFramework/blob/main/REGISTRATION-GUARD.md">
+ * Registration Guard documentation</a> for the full SPI reference.</p>
+ *
+ * @see RegistrationGuard
+ * @see RegistrationContext
+ * @see RegistrationDecision
+ */
+@Slf4j
+@Component
+@Profile("registration-guard")
+public class DomainRegistrationGuard implements RegistrationGuard {
+
+    private static final String ALLOWED_DOMAIN = "@example.com";
+
+    @Override
+    public RegistrationDecision evaluate(RegistrationContext context) {
+        log.debug("Evaluating registration for email: {}, source: {}, provider: {}",
+                context.email(), context.source(), context.providerName());
+
+        // Allow all OAuth2/OIDC registrations regardless of email domain
+        if (context.source() == RegistrationSource.OAUTH2
+                || context.source() == RegistrationSource.OIDC) {
+            log.debug("Allowing {} registration for: {}", context.source(), context.email());
+            return RegistrationDecision.allow();
+        }
+
+        // For form/passwordless, restrict to the allowed domain
+        if (context.email() != null && context.email().toLowerCase().endsWith(ALLOWED_DOMAIN)) {
+            log.debug("Allowing registration for approved domain: {}", context.email());
+            return RegistrationDecision.allow();
+        }
+
+        log.info("Denied registration for: {} (domain not allowed)", context.email());
+        return RegistrationDecision.deny(
+                "Registration is restricted to " + ALLOWED_DOMAIN + " email addresses.");
+    }
+}

--- a/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuard.java
@@ -1,5 +1,7 @@
 package com.digitalsanctuary.spring.demo.registration;
 
+import java.util.Locale;
+
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +51,7 @@ public class DomainRegistrationGuard implements RegistrationGuard {
         }
 
         // For form/passwordless, restrict to the allowed domain
-        if (context.email() != null && context.email().toLowerCase().endsWith(ALLOWED_DOMAIN)) {
+        if (context.email() != null && context.email().toLowerCase(Locale.ROOT).endsWith(ALLOWED_DOMAIN)) {
             log.debug("Allowing registration for approved domain: {}", context.email());
             return RegistrationDecision.allow();
         }

--- a/src/test/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuardTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/demo/registration/DomainRegistrationGuardTest.java
@@ -1,0 +1,89 @@
+package com.digitalsanctuary.spring.demo.registration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.digitalsanctuary.spring.user.registration.RegistrationContext;
+import com.digitalsanctuary.spring.user.registration.RegistrationDecision;
+import com.digitalsanctuary.spring.user.registration.RegistrationSource;
+
+class DomainRegistrationGuardTest {
+
+    private final DomainRegistrationGuard guard = new DomainRegistrationGuard("@example.com");
+
+    @Test
+    void formRegistrationWithAllowedDomainIsAllowed() {
+        RegistrationContext context = new RegistrationContext("user@example.com", RegistrationSource.FORM, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertTrue(decision.allowed());
+    }
+
+    @Test
+    void formRegistrationWithDisallowedDomainIsDenied() {
+        RegistrationContext context = new RegistrationContext("user@other.com", RegistrationSource.FORM, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertFalse(decision.allowed());
+        assertTrue(decision.reason().contains("@example.com"));
+    }
+
+    @Test
+    void passwordlessRegistrationWithAllowedDomainIsAllowed() {
+        RegistrationContext context = new RegistrationContext("user@example.com", RegistrationSource.PASSWORDLESS, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertTrue(decision.allowed());
+    }
+
+    @Test
+    void passwordlessRegistrationWithDisallowedDomainIsDenied() {
+        RegistrationContext context = new RegistrationContext("user@other.com", RegistrationSource.PASSWORDLESS, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertFalse(decision.allowed());
+    }
+
+    @Test
+    void oauth2RegistrationIsAlwaysAllowed() {
+        RegistrationContext context = new RegistrationContext("user@other.com", RegistrationSource.OAUTH2, "google");
+        RegistrationDecision decision = guard.evaluate(context);
+        assertTrue(decision.allowed());
+    }
+
+    @Test
+    void oidcRegistrationIsAlwaysAllowed() {
+        RegistrationContext context = new RegistrationContext("user@other.com", RegistrationSource.OIDC, "keycloak");
+        RegistrationDecision decision = guard.evaluate(context);
+        assertTrue(decision.allowed());
+    }
+
+    @Test
+    void nullEmailIsDenied() {
+        RegistrationContext context = new RegistrationContext(null, RegistrationSource.FORM, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertFalse(decision.allowed());
+    }
+
+    @Test
+    void domainCheckIsCaseInsensitive() {
+        RegistrationContext context = new RegistrationContext("user@EXAMPLE.COM", RegistrationSource.FORM, null);
+        RegistrationDecision decision = guard.evaluate(context);
+        assertTrue(decision.allowed());
+    }
+
+    @Test
+    void customDomainIsRespected() {
+        DomainRegistrationGuard customGuard = new DomainRegistrationGuard("@mycompany.org");
+        RegistrationContext allowed = new RegistrationContext("user@mycompany.org", RegistrationSource.FORM, null);
+        RegistrationContext denied = new RegistrationContext("user@example.com", RegistrationSource.FORM, null);
+        assertTrue(customGuard.evaluate(allowed).allowed());
+        assertFalse(customGuard.evaluate(denied).allowed());
+    }
+
+    @Test
+    void configuredDomainIsCaseInsensitive() {
+        DomainRegistrationGuard upperGuard = new DomainRegistrationGuard("@EXAMPLE.COM");
+        RegistrationContext context = new RegistrationContext("user@example.com", RegistrationSource.FORM, null);
+        assertTrue(upperGuard.evaluate(context).allowed());
+    }
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/service/UserServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/service/UserServiceTest.java
@@ -55,6 +55,9 @@ public class UserServiceTest {
     @Mock
     private PasswordHistoryRepository passwordHistoryRepository;
 
+    @Mock
+    private SessionInvalidationService sessionInvalidationService;
+
     private UserService userService;
     private User testUser;
     private UserDto testUserDto;
@@ -78,7 +81,7 @@ public class UserServiceTest {
 
         userService = new UserService(userRepository, tokenRepository, passwordTokenRepository, passwordEncoder,
                 roleRepository, sessionRegistry, userEmailService, userVerificationService, authorityService,
-                dsUserDetailsService, eventPublisher, passwordHistoryRepository);
+                dsUserDetailsService, eventPublisher, passwordHistoryRepository, sessionInvalidationService);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds a profile-gated `DomainRegistrationGuard` sample that restricts form/passwordless registration to `@example.com` emails while allowing all OAuth2/OIDC registrations
- Activated only with `--spring.profiles.active=...,registration-guard`
- Bumps library dependency to `4.2.3-SNAPSHOT` for RegistrationGuard SPI classes
- Fixes `UserServiceTest` constructor for new `SessionInvalidationService` parameter

## Related

- Closes #61
- Library PR: devondragon/SpringUserFramework#271

## Test plan

- [x] `./gradlew check` passes (guard not active without profile)
- [x] Manual E2E: denied domain returns 403 with code 6 and reason message
- [x] Manual E2E: allowed domain (`@example.com`) registers successfully
- [x] Guard logs confirm bean activation and evaluation decisions