### PR TITLE
chore: adopt ds-spring-user-framework 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.1.0'
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.1.1'
 
     // WebAuthn support (Passkey authentication)
     implementation 'org.springframework.security:spring-security-webauthn'


### PR DESCRIPTION
**Draft — blocked on the 5.1.1 release.** Do not merge until `ds-spring-user-framework:5.1.1` is published to Maven Central.

Bumps `ds-spring-user-framework` `5.1.0` → `5.1.1`:
- hardened, consumer-overridable `RequestCache` (won't save browser auto-probe requests, so an icon probe can't hijack the post-login redirect)
- auto-unprotect of `/apple-touch-icon*.png`, `/favicon.*`, `/.well-known/**`

Framework PR: devondragon/SpringUserFramework#343 (merged, awaiting release).

**Note on overlap with #77:** once 5.1.1 is adopted, the framework auto-unprotects `/apple-touch-icon*.png`, so the manual `/apple-touch-icon*` whitelist entry added in #77 becomes redundant-but-harmless. Either merge #77 first (keeps the explicit demo config) or drop it in favor of the framework default — your call.

### Merge checklist
- [ ] 5.1.1 published to Maven Central
- [ ] CI green after re-run