### PR TITLE
chore: adopt ds-spring-user-framework 5.3.0 on Spring Boot 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '4.0.4'
+  id 'org.springframework.boot' version '4.1.0'
   id 'io.spring.dependency-management' version '1.1.7'
   id "com.github.ben-manes.versions" version "0.61.0"
 
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.2.0'
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.0'
 
     // WebAuthn support (Passkey authentication)
     implementation 'org.springframework.security:spring-security-webauthn'

--- a/src/main/java/com/digitalsanctuary/spring/demo/service/CustomUserEmailService.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/service/CustomUserEmailService.java
@@ -14,6 +14,7 @@ import com.digitalsanctuary.spring.user.persistence.model.User;
 import com.digitalsanctuary.spring.user.mail.MailService;
 import com.digitalsanctuary.spring.user.service.SessionInvalidationService;
 import com.digitalsanctuary.spring.user.service.TokenHasher;
+import com.digitalsanctuary.spring.user.security.UserSecurityConfigProperties;
 import com.digitalsanctuary.spring.user.service.UserEmailService;
 import com.digitalsanctuary.spring.user.service.UserVerificationService;
 
@@ -40,8 +41,10 @@ public class CustomUserEmailService extends UserEmailService {
             UserRepository userRepository,
             ApplicationEventPublisher eventPublisher,
             SessionInvalidationService sessionInvalidationService,
-            TokenHasher tokenHasher) {
-        super(mailService, userVerificationService, passwordTokenRepository, userRepository, eventPublisher, sessionInvalidationService, tokenHasher);
+            TokenHasher tokenHasher,
+            UserSecurityConfigProperties userSecurityConfig) {
+        super(mailService, userVerificationService, passwordTokenRepository, userRepository, eventPublisher, sessionInvalidationService, tokenHasher,
+                userSecurityConfig);
     }
 
     @Override

--- a/src/main/java/com/digitalsanctuary/spring/demo/web/DemoTemplateModelAdvice.java
+++ b/src/main/java/com/digitalsanctuary/spring/demo/web/DemoTemplateModelAdvice.java
@@ -1,0 +1,32 @@
+package com.digitalsanctuary.spring.demo.web;
+
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Exposes demo-only, non-{@code user.security} template values that cannot come from the framework's
+ * {@code ${userSecurity}} view.
+ *
+ * <p>Specifically {@code devOrLocalProfile}: templates previously used
+ * {@code ${@environment.acceptsProfiles('dev','local')}}, which Spring Boot 4.1.0's Thymeleaf 3.1.5
+ * rejects as SpEL bean access in the restricted (layout-decorated) expression context. Exposing the
+ * boolean as a model attribute keeps the check working as an ordinary variable reference.</p>
+ */
+@ControllerAdvice
+@RequiredArgsConstructor
+public class DemoTemplateModelAdvice {
+
+    private final Environment environment;
+
+    /**
+     * @return true when the {@code dev} or {@code local} profile is active
+     */
+    @ModelAttribute("devOrLocalProfile")
+    public boolean devOrLocalProfile() {
+        return environment.acceptsProfiles(Profiles.of("dev", "local"));
+    }
+}

--- a/src/main/resources/templates/event/details.html
+++ b/src/main/resources/templates/event/details.html
@@ -46,8 +46,8 @@
                                 <div sec:authorize="!isAuthenticated()" class="mt-3">
                                     <p>
                                         To register for the event, please
-                                        <a th:href="${@environment.getProperty('user.security.loginPageURI')}" class="btn btn-secondary">Log In</a> or
-                                        <a th:href="${@environment.getProperty('user.security.registrationURI')}"
+                                        <a th:href="${userSecurity.loginPageUri}" class="btn btn-secondary">Log In</a> or
+                                        <a th:href="${userSecurity.registrationUri}"
                                             class="btn btn-secondary">Register</a>.
                                     </p>
                                 </div>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -6,7 +6,7 @@
 				<p th:utext="#{message.created-by}"></p>
 				<p>
 					<span th:utext="#{message.copyright}"></span>
-					<span th:text="${@environment.getProperty('user.copyrightFirstYear')}" />-
+					<span th:text="${userSecurity.copyrightFirstYear}" />-
 					<span th:text="${#dates.year(#dates.createNow())}" />
 				</p>
 			</div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -21,7 +21,7 @@
 				<ul class="navbar-nav">
 					<!-- Non-Logged-In State -->
 					<li class="nav-item" sec:authorize="!isAuthenticated()">
-						<a class="nav-link" th:href="${@environment.getProperty('user.security.loginPageURI')}">
+						<a class="nav-link" th:href="${userSecurity.loginPageUri}">
 							<i class="bi bi-box-arrow-in-right"></i> Login
 						</a>
 					</li>
@@ -30,8 +30,8 @@
 							<i class="bi bi-list"></i>
 						</a>
 						<ul class="dropdown-menu dropdown-menu-end" aria-labelledby="guestDropdown">
-							<li><a class="dropdown-item" th:href="${@environment.getProperty('user.security.registrationURI')}">Register</a></li>
-							<li><a class="dropdown-item" th:href="${@environment.getProperty('user.security.forgotPasswordURI')}">Forgot Password</a>
+							<li><a class="dropdown-item" th:href="${userSecurity.registrationUri}">Register</a></li>
+							<li><a class="dropdown-item" th:href="${userSecurity.forgotPasswordUri}">Forgot Password</a>
 							</li>
 						</ul>
 					</li>
@@ -43,7 +43,7 @@
 							<i class="bi bi-person-circle"></i> Account
 						</a>
 						<ul class="dropdown-menu dropdown-menu-end" aria-labelledby="accountDropdown">
-							<li><a class="dropdown-item" th:href="${@environment.getProperty('user.security.updateUserURI')}">Update Account</a></li>
+							<li><a class="dropdown-item" th:href="${userSecurity.updateUserUri}">Update Account</a></li>
 							<li><a class="dropdown-item" th:href="@{/user/update-password.html}">Change Password</a></li>
 							<li sec:authorize="hasAuthority('ADMIN_PRIVILEGE')">
 								<a class="dropdown-item" th:href="@{/admin/actions.html}">Admin Actions</a>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -74,8 +74,8 @@
 					<p class="text-muted">
 						Ready to get started? Sign up or log in to begin your journey with us.
 					</p>
-					<a th:href="${@environment.getProperty('user.security.registrationURI')}" class="btn btn-outline-primary">Sign Up</a>
-					<a th:href="${@environment.getProperty('user.security.loginPageURI')}" class="btn btn-outline-secondary">Log In</a>
+					<a th:href="${userSecurity.registrationUri}" class="btn btn-outline-primary">Sign Up</a>
+					<a th:href="${userSecurity.loginPageUri}" class="btn btn-outline-secondary">Log In</a>
 
 				</div>
 

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta th:if="${@environment.acceptsProfiles('dev','local')}" http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    <meta th:if="${devOrLocalProfile}" http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <meta name="apple-mobile-web-app-title" content="Events R Us Demo App">
     <meta name="application-name" content="Events R Us Demo App">
 
@@ -63,7 +63,7 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Enable LiveReload in the dev and local environments -->
-    <!--<script th:if="${@environment.acceptsProfiles('dev','local')}" th:src="'https://localhost:' + ${liveReloadPort} + '/livereload.js'"></script>-->
+    <!--<script th:if="${devOrLocalProfile}" th:src="'https://localhost:' + ${liveReloadPort} + '/livereload.js'"></script>-->
 </body>
 
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -55,7 +55,7 @@
 								<p class="text-muted mb-3">or</p>
 
 								<!-- Login Form -->
-								<form th:action="${@environment.getProperty('user.security.loginActionURI')}" method="POST">
+								<form th:action="${userSecurity.loginActionUri}" method="POST">
 									<div class="row mb-3">
 										<div class="col-md-6">
 											<label for="username" class="form-label" th:utext="#{label.form.login-email}">Email</label>
@@ -87,12 +87,12 @@
 
 								<!-- Links -->
 								<p class="mt-3 mb-0 text-center">
-									<a th:href="${@environment.getProperty('user.security.registrationURI')}" class="text-decoration-none">
+									<a th:href="${userSecurity.registrationUri}" class="text-decoration-none">
 										Need to create an account? Register
 									</a>
 								</p>
 								<p class="mb-0 text-center">
-									<a th:href="${@environment.getProperty('user.security.forgotPasswordURI')}" class="text-decoration-none">
+									<a th:href="${userSecurity.forgotPasswordUri}" class="text-decoration-none">
 										Forgot Password?
 									</a>
 								</p>

--- a/src/main/resources/templates/user/register.html
+++ b/src/main/resources/templates/user/register.html
@@ -60,7 +60,7 @@
 									class="alert alert-danger text-center" role="alert">
 									<p><strong th:utext="#{registration.error.already-exists}"></strong></p>
 									<p
-										th:utext="#{registration.error.already-exists-options(${@environment.getProperty('user.security.loginPageURI')}, ${@environment.getProperty('user.security.forgotPasswordURI')})}">
+										th:utext="#{registration.error.already-exists-options(${userSecurity.loginPageUri}, ${userSecurity.forgotPasswordUri})}">
 									</p>
 								</div>
 
@@ -167,7 +167,7 @@
 								<!-- Links -->
 								<p class="mt-3 mb-0 text-center">
 									Already have an account?
-									<a th:href="${@environment.getProperty('user.security.loginPageURI')}"
+									<a th:href="${userSecurity.loginPageUri}"
 										class="text-decoration-none">
 										Login
 									</a>

--- a/src/main/resources/templates/user/registration-pending-verification.html
+++ b/src/main/resources/templates/user/registration-pending-verification.html
@@ -27,7 +27,7 @@
 
 				<div class="text-center mt-4">
 					<a href="/" class="btn btn-primary">Go to Home</a>
-					<a th:href="${@environment.getProperty('user.security.loginPageURI')}" class="btn btn-outline-secondary">Log In</a>
+					<a th:href="${userSecurity.loginPageUri}" class="btn btn-outline-secondary">Log In</a>
 				</div>
 			</div>
 		</section>

--- a/src/main/resources/templates/user/request-new-verification-email.html
+++ b/src/main/resources/templates/user/request-new-verification-email.html
@@ -26,7 +26,7 @@
 						<div id="globalError" class="alert alert-danger d-none text-center" role="alert"></div>
 						<div id="alreadyEnabledMessage" class="alert alert-warning d-none text-center" role="alert">
 							<p
-								th:utext="#{registration.error.already-verified(${@environment.getProperty('user.security.loginPageURI')}, ${@environment.getProperty('user.security.forgotPasswordURI')})}">
+								th:utext="#{registration.error.already-verified(${userSecurity.loginPageUri}, ${userSecurity.forgotPasswordUri})}">
 							</p>
 						</div>
 


### PR DESCRIPTION
Adopts Spring Boot 4.1.0 and the released ds-spring-user-framework 5.3.0, and migrates the templates off the `${@environment...}` idiom that Thymeleaf 3.1.5 rejects.

Closes #82

## Why

Boot `4.0.4 -> 4.1.0` bundles Thymeleaf `3.1.2 -> 3.1.5`. Under 3.1.5, expressions using Spring bean access — `${@environment.getProperty('user.security.*')}` and `${@environment.acceptsProfiles(...)}` — are evaluated in a restricted expression context while thymeleaf-layout-dialect decorates the page, and throw:

```
org.thymeleaf.exceptions.TemplateProcessingException:
Instantiation of new objects and access to static classes or parameters is forbidden in this context
```

That broke rendering app-wide, with `SecurityConfigurationTest` and `MfaChallengeFlowIntegrationTest` failing on the render.

## What changed

- `build.gradle`: Spring Boot `4.0.4 -> 4.1.0`, `ds-spring-user-framework` `5.1.1 -> 5.3.0`. The Boot BOM carries the bumps noted in #82 (spring-security, hibernate-validator, thymeleaf-extras-springsecurity6, postgresql, lombok).
- Templates: every `${@environment.getProperty('user.security.*')}` now reads from `${userSecurity.*}`, the secret-free view the framework exposes to templates as of 5.3.0 — `loginPageUri`, `registrationUri`, `forgotPasswordUri`, `updateUserUri`, `loginActionUri`, `copyrightFirstYear`. This covers the nine templates listed in the issue: `index.html`, `layout.html`, `fragments/header.html`, `fragments/footer.html`, `user/register.html`, `user/login.html`, `user/registration-pending-verification.html`, `user/request-new-verification-email.html`, `event/details.html`, including the usages nested inside `#{message(...)}` arguments in `register.html` and `request-new-verification-email.html`.
- New `DemoTemplateModelAdvice` (`@ControllerAdvice` + `@ModelAttribute`) exposing `${devOrLocalProfile}` for the `acceptsProfiles('dev','local')` check, which is not a `user.security` value and so has no `${userSecurity}` equivalent.
- `CustomUserEmailService`: `super(...)` updated for the 5.3.0 `UserEmailService` constructor.

No `${@environment...}` usages remain in the templates.

The issue's "framework relevance" note is addressed upstream: 5.3.0 ships `${userSecurity}` as the supported replacement, so downstream apps have a documented migration target rather than each rolling their own `@ControllerAdvice`.

## Verification

- `./gradlew clean test --refresh-dependencies` — 301 tests, 0 failures (refresh so the released 5.3.0 resolves from Maven Central, not a local snapshot).
- Playwright `--project=chromium` — 107 passed.
- Playwright `--project=chromium-mfa` — 1 passed.