### PR TITLE
chore: upgrade Spring User Framework to 5.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,9 @@ repositories {
 
 dependencies {
     // DigitalSanctuary Spring User Framework
-    // 5.3.3 adds the WebAuthn step-up primitive (SUF-02, library #365) this demo exercises.
-    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.3'
+    // 5.3.4 aligns the passkey enrollment freshness denial to HTTP 401 + step-up-required (library #371),
+    // which this demo's webauthn-register.js and step-up E2E exercise; 5.3.3 added the step-up primitive.
+    implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.4'
 
     // WebAuthn support (Passkey authentication)
     implementation 'org.springframework.security:spring-security-webauthn'


### PR DESCRIPTION
Bumps `ds-spring-user-framework` from 5.3.3 to 5.3.4 (released, live on Maven Central).

5.3.4 fixes concurrent passwordless-registration deadlocks and aligns the passkey enrollment freshness denial to `HTTP 401` + `step-up-required` (library #371). The demo's `webauthn-register.js` was updated to handle both the old 403 and the new 401 in #91, and the `chromium-step-up` E2E exercises it.

Validated locally against the identical `5.3.4-SNAPSHOT` bits via the release-integration test: demo unit/integration 312 passed, Playwright chromium 107/107, chromium-mfa 1/1, chromium-step-up 8/8. CI here re-validates against the published 5.3.4 artifact.

https://claude.ai/code/session_01KL5qvKVGQLLQDjHToy34vj