### PR TITLE
chore: bump Spring Boot to 4.1.1 and pin PostgreSQL 42.7.12 (Dependabot security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '4.1.0'
+  id 'org.springframework.boot' version '4.1.1'
   id 'io.spring.dependency-management' version '1.1.7'
   id "com.github.ben-manes.versions" version "0.61.0"
 
@@ -14,6 +14,12 @@ java {
         languageVersion = JavaLanguageVersion.of(21)
     }
 }
+
+// Force the patched PostgreSQL JDBC driver ahead of the Spring Boot 4.1.1 BOM (which still manages
+// 42.7.11). 42.7.12 fixes GHSA-j92g-9f8w-j867 (silent channel-binding auth downgrade). The demo defaults
+// to MariaDB and never opens a Postgres connection, so this is supply-chain hygiene rather than an active
+// fix; drop this override once a future Boot BOM manages 42.7.12+.
+ext['postgresql.version'] = '42.7.12'
 
 // Define the configurations used in the project
 configurations {


### PR DESCRIPTION
Clears 6 of the 9 open Dependabot alerts by moving to patched dependency versions. **None of the nine is reachable in this demo app** (verified by source analysis), so this is supply-chain hygiene rather than an active-vulnerability fix.

## Changes
- **Spring Boot `4.1.0` → `4.1.1`** — pulls patched managed BOMs:
  - `jackson-databind` 2.21.4 → **2.21.5** (fixes #72 GHSA-5gvw-p9qm-jgwh, #69 GHSA-mhm7-754m-9p8w, #58 GHSA-5jmj-h7xm-6q6v)
  - `tools.jackson` `jackson-databind` 3.1.4 → **3.1.5** (fixes #73 GHSA-5gvw-p9qm-jgwh)
  - `log4j-api` 2.25.4 → **2.25.5** (fixes #96 GHSA-qv9r-c865-cp47)
- **`ext['postgresql.version'] = '42.7.12'`** — the 4.1.1 BOM still manages 42.7.11, so pin the patched driver explicitly (fixes #66 GHSA-j92g-9f8w-j867, high — silent channel-binding auth downgrade).

## Reachability (why none is an active fix)
- **Jackson**: the app uses none of the exploited annotations (`@JsonView`, `@JsonUnwrapped`, `@JsonTypeInfo`/`EXTERNAL_PROPERTY`, per-property `@JsonIgnoreProperties`); Boot's default mapper is case-sensitive. Only its own DTOs are deserialized.
- **Log4j**: `log4j-api` is present only as the `log4j-to-slf4j` bridge target; the app logs through Logback, there's no `log4j-core`, and nothing touches the vulnerable `MapMessage` JSON path.
- **PostgreSQL**: the driver is bundled but unused — every datasource is MariaDB or H2, no `jdbc:postgresql` anywhere, and no `channelBinding`/SCRAM/SSL config. The CVE needs `channelBinding=require` over TLS plus an active MITM.

## Not addressed here (stale, no code change)
The 3 Apache HttpComponents alerts (#94, #95, #97) reference `httpclient5`/`httpcore5`/`httpcore5-h2`, which are **absent from every resolved configuration** and were never in the repo or its git history — a transitive of an older dependency the current tree no longer pulls. They clear on the next Automatic Dependency Submission to `main`; dismiss manually as "vulnerable code not present" if they linger.

## Testing
- `dependencyInsight` confirms all four now resolve to the patched versions.
- `./gradlew test` passes: 312 tests, 0 failures, 0 errors (182 profile/container-gated tests skipped, as usual).

https://claude.ai/code/session_01EJY7pA4NvY9vJt6CfDBVWt